### PR TITLE
Fix rating display for unrated media

### DIFF
--- a/Forms/StarRatingControl.cs
+++ b/Forms/StarRatingControl.cs
@@ -11,7 +11,7 @@ namespace MyAwesomeMediaManager.Forms
     public class StarRatingControl : Control
     {
         private int starCount = 5;
-        private int currentRating = 1;
+        private int currentRating = 0;
         private int hoverRating = 0;
 
         public event EventHandler<int>? RatingChanged;
@@ -31,7 +31,7 @@ namespace MyAwesomeMediaManager.Forms
             get => currentRating;
             set
             {
-                if (value < 1) value = 1;
+                if (value < 0) value = 0;
                 if (value > StarCount) value = StarCount;
                 currentRating = value;
                 Invalidate();

--- a/Forms/ThumbnailPreviewForm.cs
+++ b/Forms/ThumbnailPreviewForm.cs
@@ -28,16 +28,28 @@ public class ThumbnailPreviewForm : Form
         Deactivate += (s, e) => Close();
     }
 
+    protected override CreateParams CreateParams
+    {
+        get
+        {
+            const int WS_EX_NOACTIVATE = 0x08000000;
+            var cp = base.CreateParams;
+            cp.ExStyle |= WS_EX_NOACTIVATE;
+            return cp;
+        }
+    }
+
     public void ShowNear(Control parent)
     {
         var mainForm = parent.FindForm();
         if (mainForm == null) return;
 
-        Rectangle appBounds = mainForm.RectangleToScreen(mainForm.ClientRectangle);
+        var screenBounds = Screen.FromControl(mainForm).WorkingArea;
+        Rectangle appBounds = screenBounds;
         Point parentScreenPos = parent.PointToScreen(Point.Empty);
 
-        int maxPopupWidth = (int)(appBounds.Width * 0.8);
-        int maxPopupHeight = (int)(appBounds.Height * 0.8);
+        int maxPopupWidth = (int)(screenBounds.Width * 0.8);
+        int maxPopupHeight = (int)(screenBounds.Height * 0.8);
 
         // Calculate the preview size to fit within maxPopupWidth x maxPopupHeight, preserving aspect ratio
         int imgW = previewBox.Image.Width;


### PR DESCRIPTION
## Summary
- allow `StarRatingControl` to display zero-star ratings
- show preview popup in working area and avoid stealing focus

## Testing
- `dotnet build -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b33add964832791f5284b7486b5a4