### PR TITLE
Remove container hover handlers

### DIFF
--- a/Forms/MediaItemControl.cs
+++ b/Forms/MediaItemControl.cs
@@ -28,20 +28,6 @@ namespace MyAwesomeMediaManager.Forms
             ForeColor = Color.White;
             BorderStyle = BorderStyle.None;
 
-            void ApplyHoverHandlers(Control control)
-            {
-                control.MouseEnter += (s, e) => this.BackColor = Color.FromArgb(60, 60, 60);
-                control.MouseLeave += (s, e) =>
-                {
-                    if (!this.ClientRectangle.Contains(this.PointToClient(Cursor.Position)))
-                    {
-                        this.BackColor = ratingControl.CurrentRating > 0 ? Color.FromArgb(45, 45, 45) : Color.FromArgb(70, 60, 30);
-                    }
-                };
-
-                foreach (Control child in control.Controls)
-                    ApplyHoverHandlers(child);
-            }
 
             thumbnailBox = new PictureBox
             {
@@ -102,9 +88,6 @@ namespace MyAwesomeMediaManager.Forms
 
             Controls.Add(thumbnailBox);
             Controls.Add(ratingControl);
-
-            // Wire hover events after child controls are in place
-            ApplyHoverHandlers(this);
 
             thumbnailBox.MouseEnter += (s, e) =>
             {


### PR DESCRIPTION
## Summary
- delete `ApplyHoverHandlers` local function from `MediaItemControl`
- stop wiring container-level mouse enter/leave events

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b3f6ef27883278e0c1317031eac43