### PR TITLE
Fix borderless maximize padding

### DIFF
--- a/Forms/MainForm.cs
+++ b/Forms/MainForm.cs
@@ -49,6 +49,9 @@ namespace MyAwesomeMediaManager
 
         private const int RESIZE_HANDLE_SIZE = 10;
 
+        private static readonly Color BORDER_COLOR = Color.DarkBlue;
+        private const int BORDER_THICKNESS = 2;
+
         public MainForm()
         {
             InitializeComponent();
@@ -71,7 +74,18 @@ namespace MyAwesomeMediaManager
 
         private void MainForm_Resize(object? sender, EventArgs e)
         {
+            // Adjust padding based on window state to emulate Chrome-like border
+            if (this.WindowState == FormWindowState.Maximized)
+            {
+                this.Padding = new Padding(0);
+            }
+            else
+            {
+                this.Padding = new Padding(2);
+            }
+
             LayoutThumbnails();
+            this.Invalidate();
         }
 
 
@@ -79,7 +93,8 @@ namespace MyAwesomeMediaManager
         {
             // Form settings
             this.FormBorderStyle = FormBorderStyle.None;
-            this.Padding = new Padding(10); // padding for resize area
+            // Small padding so window has a subtle border when not maximized
+            this.Padding = new Padding(2);
             this.BackColor = Color.FromArgb(30, 30, 30);
             this.ForeColor = Color.White;
             this.Font = new Font("Segoe UI", 10);
@@ -201,6 +216,9 @@ namespace MyAwesomeMediaManager
         {
             base.OnHandleCreated(e);
 
+            // Constrain maximized bounds to working area so taskbar remains visible
+            this.MaximizedBounds = Screen.FromHandle(this.Handle).WorkingArea;
+
             // Make window resizable with borderless style
             int style = NativeMethods.GetWindowLong(this.Handle, GWL_STYLE);
             style |= WS_THICKFRAME;
@@ -321,6 +339,23 @@ namespace MyAwesomeMediaManager
             // Force layout update and redraw
             flowPanel.PerformLayout();
             flowPanel.Invalidate();
+        }
+
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            base.OnPaint(e);
+
+            if (this.WindowState != FormWindowState.Maximized)
+            {
+                ControlPaint.DrawBorder(
+                    e.Graphics,
+                    this.ClientRectangle,
+                    BORDER_COLOR, BORDER_THICKNESS, ButtonBorderStyle.Solid,
+                    Color.Transparent, 0, ButtonBorderStyle.None,
+                    BORDER_COLOR, BORDER_THICKNESS, ButtonBorderStyle.Solid,
+                    BORDER_COLOR, BORDER_THICKNESS, ButtonBorderStyle.Solid);
+            }
         }
 
 


### PR DESCRIPTION
## Summary
- prevent borderless window from covering the taskbar by constraining `MaximizedBounds`
- add subtle 2px border for normal state and remove padding when maximized
- draw a darkblue border on the left, right, and bottom edges when not maximized

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b4c8b60848327b0c4c8f43e8c5a5e