### PR TITLE
Fix borderless maximize padding

### DIFF
--- a/Forms/MainForm.cs
+++ b/Forms/MainForm.cs
@@ -49,6 +49,9 @@ namespace MyAwesomeMediaManager
 
         private const int RESIZE_HANDLE_SIZE = 10;
 
+        private static readonly Color BORDER_COLOR = Color.DarkBlue;
+        private const int BORDER_THICKNESS = 2;
+
         public MainForm()
         {
             InitializeComponent();
@@ -71,7 +74,18 @@ namespace MyAwesomeMediaManager
 
         private void MainForm_Resize(object? sender, EventArgs e)
         {
+            // Adjust padding based on window state to emulate Chrome-like border
+            if (this.WindowState == FormWindowState.Maximized)
+            {
+                this.Padding = new Padding(0);
+            }
+            else
+            {
+                this.Padding = new Padding(2);
+            }
+
             LayoutThumbnails();
+            this.Invalidate();
         }
 
 
@@ -79,7 +93,8 @@ namespace MyAwesomeMediaManager
         {
             // Form settings
             this.FormBorderStyle = FormBorderStyle.None;
-            this.Padding = new Padding(10); // padding for resize area
+            // Small padding so window has a subtle border when not maximized
+            this.Padding = new Padding(2);
             this.BackColor = Color.FromArgb(30, 30, 30);
             this.ForeColor = Color.White;
             this.Font = new Font("Segoe UI", 10);
@@ -201,6 +216,9 @@ namespace MyAwesomeMediaManager
         {
             base.OnHandleCreated(e);
 
+            // Constrain maximized bounds to working area so taskbar remains visible
+            this.MaximizedBounds = Screen.FromHandle(this.Handle).WorkingArea;
+
             // Make window resizable with borderless style
             int style = NativeMethods.GetWindowLong(this.Handle, GWL_STYLE);
             style |= WS_THICKFRAME;
@@ -321,6 +339,23 @@ namespace MyAwesomeMediaManager
             // Force layout update and redraw
             flowPanel.PerformLayout();
             flowPanel.Invalidate();
+        }
+
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            base.OnPaint(e);
+
+            if (this.WindowState != FormWindowState.Maximized)
+            {
+                ControlPaint.DrawBorder(
+                    e.Graphics,
+                    this.ClientRectangle,
+                    BORDER_COLOR, BORDER_THICKNESS, ButtonBorderStyle.Solid,
+                    Color.Transparent, 0, ButtonBorderStyle.None,
+                    BORDER_COLOR, BORDER_THICKNESS, ButtonBorderStyle.Solid,
+                    BORDER_COLOR, BORDER_THICKNESS, ButtonBorderStyle.Solid);
+            }
         }
 
 

--- a/Forms/MediaModalForm.cs
+++ b/Forms/MediaModalForm.cs
@@ -428,29 +428,52 @@ namespace MyAwesomeMediaManager.Forms
         {
             if (!File.Exists(filePath)) return;
 
+            bool isVideo = IsVideoFile(filePath);
+            bool isImage = IsImageFile(filePath);
+
             if (_videoView != null)
             {
                 this.Controls.Remove(_videoView);
                 _videoView.Dispose();
+                _videoView = null;
             }
 
-            _libVLC = new LibVLC();
-            _mediaPlayer = new VLCMediaPlayer(_libVLC);
-
-            _videoView = new VideoView
+            if (_imageBox != null)
             {
-                MediaPlayer = _mediaPlayer,
-                Dock = DockStyle.Fill,
-                BackColor = Color.Black
-            };
-            this.Controls.Add(_videoView);
-            _videoView.BringToFront();
+                this.Controls.Remove(_imageBox);
+                _imageBox.Dispose();
+                _imageBox = null;
+            }
 
-            var media = new Media(_libVLC, new Uri(filePath));
-            _mediaPlayer.Play(media);
+            if (isVideo)
+            {
+                _libVLC = new LibVLC();
+                _mediaPlayer = new VLCMediaPlayer(_libVLC);
 
-            bool isVideo = IsVideoFile(filePath);
-            bool isImage = IsImageFile(filePath);
+                _videoView = new VideoView
+                {
+                    MediaPlayer = _mediaPlayer,
+                    Dock = DockStyle.Fill,
+                    BackColor = Color.Black
+                };
+                this.Controls.Add(_videoView);
+                _videoView.BringToFront();
+
+                var media = new Media(_libVLC, new Uri(filePath));
+                _mediaPlayer.Play(media);
+            }
+            else if (isImage)
+            {
+                _imageBox = new PictureBox
+                {
+                    Image = Image.FromFile(filePath),
+                    SizeMode = PictureBoxSizeMode.Zoom,
+                    Dock = DockStyle.Fill,
+                    BackColor = Color.Black
+                };
+                this.Controls.Add(_imageBox);
+                _imageBox.BringToFront();
+            }
 
             AddPlaybackControls(showPlaybackControls: isVideo);
             _controlPanel?.BringToFront();

--- a/Program.cs
+++ b/Program.cs
@@ -16,9 +16,15 @@ namespace MyAwesomeMediaManager
 
             var folders = DatabaseHelper.GetAllFolders();
             if (folders.Count == 0)
+            {
                 Application.Run(new FolderSetupForm());
+            }
             else
-                Application.Run(new MainForm());
+            {
+                var main = new MainForm();
+                main.WindowState = FormWindowState.Maximized;
+                Application.Run(main);
+            }
         }
 
     }


### PR DESCRIPTION
## Summary
- prevent borderless window from covering the taskbar by constraining `MaximizedBounds`
- add subtle 2px border for normal state and remove padding when maximized
- draw a darkblue border on the left, right, and bottom edges when not maximized
- start MainForm maximized
- render images, including animated GIFs, using a `PictureBox` in `MediaModalForm`

## Testing
- ❌ `dotnet build` (failed: `dotnet` not found)


------
https://chatgpt.com/codex/tasks/task_e_684b4c8b60848327b0c4c8f43e8c5a5e