### PR TITLE
Fix preview closure when opening viewer

### DIFF
--- a/Forms/MediaItemControl.cs
+++ b/Forms/MediaItemControl.cs
@@ -234,8 +234,13 @@ namespace MyAwesomeMediaManager.Forms
 
         private void OnThumbnailClicked()
         {
+            // Hide any preview popup before opening the modal viewer
+            HidePreview();
+
             var modal = new MediaModalForm(FilePath, FindForm());
             modal.Show();
+            // Ensure the modal stays above other windows
+            modal.BringToFront();
         }
 
     }


### PR DESCRIPTION
## Summary
- close preview popup when thumbnail is clicked
- keep modal viewer on top when opened

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c9d51d5148327a6431331e825ffa8